### PR TITLE
Option removed from Data.Semigroup

### DIFF
--- a/endo.cabal
+++ b/endo.cabal
@@ -135,10 +135,6 @@ library
       -- only with transformers >=0.5.
       -DHAVE_FUNCTOR_CLASSES
 
-      -- Package base ==4.9.0.0 introduces Data.Semigroup, which was originally
-      -- defined in semigroups package.
-      -DHAVE_SEMIGROUPS
-
   ghc-options:          -Wall
   if flag(pedantic)
     if impl(GHC <8)

--- a/src/Data/Monoid/Endo/AnEndo.hs
+++ b/src/Data/Monoid/Endo/AnEndo.hs
@@ -81,9 +81,6 @@ import Data.Monoid
     , Monoid(mempty, mconcat)
     , (<>)
     )
-#ifdef HAVE_SEMIGROUPS
-import Data.Semigroup (Option(Option))
-#endif
 import Data.Traversable (Traversable)
 import GHC.Generics (Generic, Generic1)
 import Text.Read (Read)
@@ -198,16 +195,6 @@ instance AnEndo (Proxy a) where
 
     anEndo    Proxy = mempty
     aDualEndo Proxy = mempty
-#endif
-
-#ifdef HAVE_SEMIGROUPS
--- | Has same semantics as 'Maybe' and it is actually defined in terms of
--- 'AnEndo' instance for 'Maybe'.
-instance AnEndo a => AnEndo (Option a) where
-    type EndoOperatesOn (Option a) = EndoOperatesOn a
-
-    anEndo (Option maybe) = anEndo maybe
-    aDualEndo (Option maybe) = aDualEndo maybe
 #endif
 
 -- {{{ Foldable Instances -----------------------------------------------------


### PR DESCRIPTION
Per the documentation from the base package itself

> In GHC 8.4 and higher, the 'Monoid' instance for 'Maybe' has been corrected to lift a 'Semigroup' instance instead of a 'Monoid' instance. Consequently, this type is no longer useful. It will be marked deprecated in GHC 8.8 and removed in GHC 8.10.

As it stands now, the `Maybe` type has a Semigroup instance. Option would serve no purpose here for anyone on at least base>=4.11.0.0. Perhaps the .cabal needs to be updated as well to account for this?